### PR TITLE
OPS-16603 do not renew

### DIFF
--- a/src/vault-auth-chef/chefclient/path_auth.go
+++ b/src/vault-auth-chef/chefclient/path_auth.go
@@ -75,7 +75,7 @@ func (b *backend) pathAuthLogin(ctx context.Context, req *logical.Request, d *fr
 			DisplayName: creds.node.Name,
 			LeaseOptions: logical.LeaseOptions{
 				TTL:       creds.ttl,
-				Renewable: true,
+				Renewable: false,
 			},
 		},
 	}, nil


### PR DESCRIPTION
Looks like we're not using cert renew anywhere, and this caused some 600k certs to stuff consul with expiry records. Not great.